### PR TITLE
引数が誤っているケースへの対応

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -84,6 +84,27 @@ class TestKanjize(unittest.TestCase):
         # added 1.4.0
         self.assertEqual(0, kanji2number("零"))
 
+        # added after 1.4.0
+        self.assertEqual(12345, kanji2number("12千345"))
+        with self.assertRaises(ValueError):
+            kanji2number("1千1000")
+        with self.assertRaises(ValueError):
+            kanji2number("1万10千")
+        with self.assertRaises(ValueError):
+            kanji2number("万1千234")
+        with self.assertRaises(ValueError):
+            kanji2number("1万0万")
+        with self.assertRaises(ValueError):
+            kanji2number("1万.00009億")
+        with self.assertRaises(ValueError):
+            kanji2number("1億-2万")
+        with self.assertRaises(ValueError):
+            kanji2number("1万+2")
+        with self.assertRaises(ValueError):
+            kanji2number("千2e1")
+        with self.assertRaises(ValueError):
+            kanji2number("inf")
+
     def test_number2kanji(self):
         self.assertEqual(number2kanji(1), "一", "all")
         self.assertEqual(number2kanji(10), "十", "all")


### PR DESCRIPTION
v1.3.0

次のような誤った (または不合理な) 引数に対し、意味不明な値を返してしまいます。

``` python
>>> from kanjize import kanji2number
>>> kanji2number("1千1234")
2234
>>> kanji2number("1万12千345")
22345
>>> kanji2number("1億-2万")
99980000
>>> kanji2number("千2e1")
1020
>>>
```

次のような誤っている (と思われる※) 引数でクラッシュします。

``` python
>>> kanji2number("万1千234")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../kanjize/kanjize.py", line 99, in kanji2number
    result += kanji2number(kanjis)
  File "/.../kanjize/kanjize.py", line 99, in kanji2number
    result += kanji2number(kanjis)
  File "/.../kanjize/kanjize.py", line 99, in kanji2number
    result += kanji2number(kanjis)
  [Previous line repeated 992 more times]
  File "/.../kanjize/kanjize.py", line 89, in kanji2number
    match = re.compile(r'(?:(.+?)({}))?(.*)'.format('|'.join(digit_dict.keys()))).match(kanjis)
  File "/usr/lib64/python3.6/re.py", line 233, in compile
    return _compile(pattern, flags)
  File "/usr/lib64/python3.6/re.py", line 289, in _compile
    p, loc = _cache[type(pattern), pattern, flags]
RecursionError: maximum recursion depth exceeded in comparison
```

※「万」以上の単位の前には倍数が必要だと思います (例えば "万" ではなく "1万" のように書く)。

当PRで、以上のような場合はいずれもValueError例外を送出するようになります。

---
[EDIT] 間違いがあったので再pushしました。